### PR TITLE
BAU: Add class to consume new trust store config and deprecate old method

### DIFF
--- a/saml-metadata-bindings/src/main/java/uk/gov/ida/saml/metadata/MetadataConfiguration.java
+++ b/saml-metadata-bindings/src/main/java/uk/gov/ida/saml/metadata/MetadataConfiguration.java
@@ -1,19 +1,20 @@
 package uk.gov.ida.saml.metadata;
 
+import com.fasterxml.jackson.annotation.JsonAlias;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.dropwizard.client.JerseyClientConfiguration;
+import uk.gov.ida.saml.metadata.factories.MetadataTrustStoreProvider;
 
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
 import java.net.URI;
+import java.security.KeyStore;
 
-public class MetadataConfiguration implements MetadataResolverConfiguration {
+public abstract class MetadataConfiguration implements MetadataResolverConfiguration {
     protected MetadataConfiguration() {
     }
 
-    public MetadataConfiguration(String trustStorePath, String trustStorePassword, URI uri, Long minRefreshDelay, Long maxRefreshDelay, String expectedEntityId, JerseyClientConfiguration client, String jerseyClientName) {
-        this.trustStorePath = trustStorePath;
-        this.trustStorePassword = trustStorePassword;
+    public MetadataConfiguration(URI uri, Long minRefreshDelay, Long maxRefreshDelay, String expectedEntityId, JerseyClientConfiguration client, String jerseyClientName) {
         this.uri = uri;
         this.minRefreshDelay = minRefreshDelay;
         this.maxRefreshDelay = maxRefreshDelay;
@@ -22,23 +23,11 @@ public class MetadataConfiguration implements MetadataResolverConfiguration {
         this.jerseyClientName = jerseyClientName;
     }
 
-    /*
-     * TrustStore configuration is used to do certificate chain validation when loading metadata
-     */
-    @NotNull
-    @Valid
-    @JsonProperty
-    private String trustStorePath;
-
-    @NotNull
-    @Valid
-    @JsonProperty
-    private String trustStorePassword;
-
     /* HTTP{S} URL the SAML metadata can be loaded from */
     @NotNull
     @Valid
     @JsonProperty
+    @JsonAlias({ "url" })
     private URI uri;
 
     /* Used to set {@link org.opensaml.saml2.metadata.provider.AbstractReloadingMetadataProvider#minRefreshDelay} */
@@ -71,16 +60,6 @@ public class MetadataConfiguration implements MetadataResolverConfiguration {
     @Valid
     @JsonProperty
     private String jerseyClientName = "MetadataClient";
-
-    @Override
-    public String getTrustStorePath() {
-        return trustStorePath;
-    }
-
-    @Override
-    public String getTrustStorePassword() {
-        return trustStorePassword;
-    }
 
     @Override
     public URI getUri() {

--- a/saml-metadata-bindings/src/main/java/uk/gov/ida/saml/metadata/MetadataResolverConfiguration.java
+++ b/saml-metadata-bindings/src/main/java/uk/gov/ida/saml/metadata/MetadataResolverConfiguration.java
@@ -3,12 +3,11 @@ package uk.gov.ida.saml.metadata;
 import io.dropwizard.client.JerseyClientConfiguration;
 
 import java.net.URI;
+import java.security.KeyStore;
 
 public interface MetadataResolverConfiguration {
 
-    public String getTrustStorePath();
-
-    public String getTrustStorePassword();
+    public KeyStore getTrustStore();
 
     public URI getUri();
 

--- a/saml-metadata-bindings/src/main/java/uk/gov/ida/saml/metadata/TrustStoreBackedMetadataConfiguration.java
+++ b/saml-metadata-bindings/src/main/java/uk/gov/ida/saml/metadata/TrustStoreBackedMetadataConfiguration.java
@@ -1,0 +1,20 @@
+package uk.gov.ida.saml.metadata;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import javax.validation.Valid;
+import javax.validation.constraints.NotNull;
+import java.security.KeyStore;
+
+public class TrustStoreBackedMetadataConfiguration extends MetadataConfiguration {
+
+    @NotNull
+    @Valid
+    @JsonProperty
+    private TrustStoreConfiguration trustStore;
+
+    @Override
+    public KeyStore getTrustStore() {
+        return trustStore.getTrustStore();
+    }
+}

--- a/saml-metadata-bindings/src/main/java/uk/gov/ida/saml/metadata/TrustStorePathMetadataConfiguration.java
+++ b/saml-metadata-bindings/src/main/java/uk/gov/ida/saml/metadata/TrustStorePathMetadataConfiguration.java
@@ -1,0 +1,45 @@
+package uk.gov.ida.saml.metadata;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.dropwizard.client.JerseyClientConfiguration;
+import uk.gov.ida.saml.metadata.factories.MetadataTrustStoreProvider;
+
+import javax.validation.Valid;
+import javax.validation.constraints.NotNull;
+import java.net.URI;
+import java.security.KeyStore;
+
+/**
+ * Uses a flat structure to parse metadata details
+ *
+ * @deprecated Use {@link TrustStoreBackedMetadataConfiguration} instead. This will change configs
+ * to use a nested trust store object instead of having path and password as part of the metadata configuration.
+ */
+@Deprecated
+public class TrustStorePathMetadataConfiguration extends MetadataConfiguration {
+    protected TrustStorePathMetadataConfiguration() {
+    }
+
+    public TrustStorePathMetadataConfiguration(String trustStorePath, String trustStorePassword, URI uri, Long minRefreshDelay, Long maxRefreshDelay, String expectedEntityId, JerseyClientConfiguration client, String jerseyClientName) {
+        this.trustStorePath = trustStorePath;
+        this.trustStorePassword = trustStorePassword;
+    }
+
+    /*
+     * TrustStore configuration is used to do certificate chain validation when loading metadata
+     */
+    @NotNull
+    @Valid
+    @JsonProperty
+    private String trustStorePath;
+
+    @NotNull
+    @Valid
+    @JsonProperty
+    private String trustStorePassword;
+
+    @Override
+    public KeyStore getTrustStore() {
+        return new MetadataTrustStoreProvider(new KeyStoreLoader(), trustStorePath, trustStorePassword).get();
+    }
+}

--- a/saml-metadata-bindings/src/main/java/uk/gov/ida/saml/metadata/bundle/MetadataResolverBundle.java
+++ b/saml-metadata-bindings/src/main/java/uk/gov/ida/saml/metadata/bundle/MetadataResolverBundle.java
@@ -5,7 +5,7 @@ import io.dropwizard.Configuration;
 import io.dropwizard.setup.Bootstrap;
 import io.dropwizard.setup.Environment;
 import org.opensaml.saml.metadata.resolver.MetadataResolver;
-import uk.gov.ida.saml.metadata.MetadataConfiguration;
+import uk.gov.ida.saml.metadata.MetadataResolverConfiguration;
 import uk.gov.ida.saml.metadata.factories.DropwizardMetadataResolverFactory;
 
 import javax.inject.Provider;
@@ -21,7 +21,7 @@ public class MetadataResolverBundle<T extends Configuration> implements io.dropw
 
     @Override
     public void run(T configuration, Environment environment) throws Exception {
-        MetadataConfiguration metadataConfiguration = configExtractor.getMetadataConfiguration(configuration);
+        MetadataResolverConfiguration metadataConfiguration = configExtractor.getMetadataConfiguration(configuration);
         metadataResolver = dropwizardMetadataResolverFactory.createMetadataResolver(environment, metadataConfiguration);
     }
 
@@ -43,7 +43,7 @@ public class MetadataResolverBundle<T extends Configuration> implements io.dropw
     }
 
     public interface MetadataConfigurationExtractor<T> {
-        MetadataConfiguration getMetadataConfiguration(T configuration);
+        MetadataResolverConfiguration getMetadataConfiguration(T configuration);
     }
 
 }

--- a/saml-metadata-bindings/src/main/java/uk/gov/ida/saml/metadata/factories/DropwizardMetadataResolverFactory.java
+++ b/saml-metadata-bindings/src/main/java/uk/gov/ida/saml/metadata/factories/DropwizardMetadataResolverFactory.java
@@ -4,7 +4,6 @@ import io.dropwizard.setup.Environment;
 import org.opensaml.saml.metadata.resolver.MetadataResolver;
 import org.opensaml.saml.metadata.resolver.filter.MetadataFilter;
 import uk.gov.ida.saml.metadata.ExpiredCertificateMetadataFilter;
-import uk.gov.ida.saml.metadata.KeyStoreLoader;
 import uk.gov.ida.saml.metadata.MetadataResolverConfiguration;
 import uk.gov.ida.saml.metadata.PKIXSignatureValidationFilterProvider;
 
@@ -47,12 +46,8 @@ public class DropwizardMetadataResolverFactory {
     private List<MetadataFilter> getMetadataFilters(MetadataResolverConfiguration metadataConfiguration, boolean validateSignatures) {
         if (!validateSignatures) { return emptyList(); }
 
-        KeyStore metadataTrustStore = getMetadataTrustStore(metadataConfiguration);
+        KeyStore metadataTrustStore = metadataConfiguration.getTrustStore();
         PKIXSignatureValidationFilterProvider pkixSignatureValidationFilterProvider = new PKIXSignatureValidationFilterProvider(metadataTrustStore);
         return asList(pkixSignatureValidationFilterProvider.get(), expiredCertificateMetadataFilter);
-    }
-
-    private KeyStore getMetadataTrustStore(MetadataResolverConfiguration metadataConfiguration) {
-        return new MetadataTrustStoreProvider(new KeyStoreLoader(), metadataConfiguration.getTrustStorePath(), metadataConfiguration.getTrustStorePassword()).get();
     }
 }

--- a/saml-metadata-bindings/src/main/java/uk/gov/ida/saml/metadata/factories/MetadataClientFactory.java
+++ b/saml-metadata-bindings/src/main/java/uk/gov/ida/saml/metadata/factories/MetadataClientFactory.java
@@ -4,7 +4,6 @@ import io.dropwizard.client.JerseyClientBuilder;
 import io.dropwizard.client.JerseyClientConfiguration;
 import io.dropwizard.setup.Environment;
 import org.apache.http.impl.conn.SystemDefaultRoutePlanner;
-import uk.gov.ida.saml.metadata.MetadataConfiguration;
 import uk.gov.ida.saml.metadata.MetadataResolverConfiguration;
 
 import javax.ws.rs.client.Client;

--- a/saml-metadata-bindings/src/test/java/uk/gov/ida/saml/metadata/SamlMetadataBundleTest.java
+++ b/saml-metadata-bindings/src/test/java/uk/gov/ida/saml/metadata/SamlMetadataBundleTest.java
@@ -71,9 +71,9 @@ public class SamlMetadataBundleTest {
 
     public static class TestConfiguration extends Configuration {
         @JsonProperty("metadata")
-        MetadataConfiguration metadataConfiguration;
+        TrustStorePathMetadataConfiguration metadataConfiguration;
 
-        public MetadataConfiguration getMetadataConfiguration() {
+        public MetadataResolverConfiguration getMetadataConfiguration() {
             return metadataConfiguration;
         }
     }

--- a/saml-metadata-bindings/src/test/java/uk/gov/ida/saml/metadata/factories/MetadataResolverFactoryTest.java
+++ b/saml-metadata-bindings/src/test/java/uk/gov/ida/saml/metadata/factories/MetadataResolverFactoryTest.java
@@ -12,7 +12,7 @@ import org.opensaml.saml.saml2.metadata.EntityDescriptor;
 import uk.gov.ida.saml.metadata.EntitiesDescriptorNameCriterion;
 import uk.gov.ida.saml.metadata.EntitiesDescriptorNamePredicate;
 import uk.gov.ida.saml.metadata.ExpiredCertificateMetadataFilter;
-import uk.gov.ida.saml.metadata.MetadataConfiguration;
+import uk.gov.ida.saml.metadata.MetadataResolverConfiguration;
 
 import javax.ws.rs.client.Client;
 import java.net.URI;
@@ -22,7 +22,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class MetadataResolverFactoryTest {
     @Mock
-    MetadataConfiguration configuration;
+    MetadataResolverConfiguration configuration;
 
     @Mock
     Environment environment;


### PR DESCRIPTION
Added a MetadataConfiguration to use the new polymorphic trust store config
whilst maintaining a deprecated subclass that permits the old/flat config
format. All configs previously using MetadataConfiguration should now use
TrustStorePathMetadataConfiguration as an identical replacement

Authors: @andy-paine