### PR TITLE
BAU: Move json to JsonCreator and add defaults for JerseyClient in metadata

### DIFF
--- a/saml-metadata-bindings/src/main/java/uk/gov/ida/saml/metadata/MetadataConfiguration.java
+++ b/saml-metadata-bindings/src/main/java/uk/gov/ida/saml/metadata/MetadataConfiguration.java
@@ -1,65 +1,44 @@
 package uk.gov.ida.saml.metadata;
 
-import com.fasterxml.jackson.annotation.JsonAlias;
-import com.fasterxml.jackson.annotation.JsonProperty;
 import io.dropwizard.client.JerseyClientConfiguration;
-import uk.gov.ida.saml.metadata.factories.MetadataTrustStoreProvider;
 
-import javax.validation.Valid;
-import javax.validation.constraints.NotNull;
 import java.net.URI;
-import java.security.KeyStore;
+import java.util.Optional;
 
 public abstract class MetadataConfiguration implements MetadataResolverConfiguration {
-    protected MetadataConfiguration() {
-    }
-
-    public MetadataConfiguration(URI uri, Long minRefreshDelay, Long maxRefreshDelay, String expectedEntityId, JerseyClientConfiguration client, String jerseyClientName) {
+    public MetadataConfiguration(URI uri,
+        Long minRefreshDelay,
+        Long maxRefreshDelay,
+        String expectedEntityId,
+        JerseyClientConfiguration client,
+        String jerseyClientName
+    ) {
         this.uri = uri;
-        this.minRefreshDelay = minRefreshDelay;
-        this.maxRefreshDelay = maxRefreshDelay;
-        this.expectedEntityId = expectedEntityId;
-        this.client = client;
-        this.jerseyClientName = jerseyClientName;
+        this.minRefreshDelay = Optional.ofNullable(minRefreshDelay).orElse(60000L);
+        this.maxRefreshDelay = Optional.ofNullable(maxRefreshDelay).orElse(600000L);
+        this.expectedEntityId = Optional.ofNullable(expectedEntityId).orElse("https://signin.service.gov.uk");
+        this.client = Optional.ofNullable(client).orElse(new JerseyClientConfiguration());
+        this.jerseyClientName = Optional.ofNullable(jerseyClientName).orElse("MetadataClient");
     }
 
     /* HTTP{S} URL the SAML metadata can be loaded from */
-    @NotNull
-    @Valid
-    @JsonProperty
-    @JsonAlias({ "url" })
     private URI uri;
 
     /* Used to set {@link org.opensaml.saml2.metadata.provider.AbstractReloadingMetadataProvider#minRefreshDelay} */
-    @Valid
-    @NotNull
-    @JsonProperty
     private Long minRefreshDelay;
 
     /* Used to set {@link org.opensaml.saml2.metadata.provider.AbstractReloadingMetadataProvider#maxRefreshDelay} */
-    @Valid
-    @NotNull
-    @JsonProperty
     private Long maxRefreshDelay;
 
     /*
     * What entityId can be expected to reliably appear in the SAML metadata?
     * Used to provide a healthcheck {@link uk.gov.ida.saml.dropwizard.metadata.MetadataHealthCheck}
     */
-    @NotNull
-    @Valid
-    @JsonProperty
     private String expectedEntityId;
 
-    @NotNull
-    @Valid
-    @JsonProperty
     private JerseyClientConfiguration client;
 
-    @NotNull
-    @Valid
-    @JsonProperty
-    private String jerseyClientName = "MetadataClient";
+    private String jerseyClientName;
 
     @Override
     public URI getUri() {

--- a/saml-metadata-bindings/src/main/java/uk/gov/ida/saml/metadata/TrustStoreBackedMetadataConfiguration.java
+++ b/saml-metadata-bindings/src/main/java/uk/gov/ida/saml/metadata/TrustStoreBackedMetadataConfiguration.java
@@ -1,16 +1,33 @@
 package uk.gov.ida.saml.metadata;
 
+import com.fasterxml.jackson.annotation.JsonAlias;
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import io.dropwizard.client.JerseyClientConfiguration;
 
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
+import java.net.URI;
 import java.security.KeyStore;
 
 public class TrustStoreBackedMetadataConfiguration extends MetadataConfiguration {
 
+    @JsonCreator
+    public TrustStoreBackedMetadataConfiguration(
+        @JsonProperty("uri") @JsonAlias({ "url" }) URI uri,
+        @JsonProperty("minRefreshDelay") Long minRefreshDelay,
+        @JsonProperty("maxRefreshDelay") Long maxRefreshDelay,
+        @JsonProperty("expectedEntityId") String expectedEntityId,
+        @JsonProperty("client") JerseyClientConfiguration client,
+        @JsonProperty("jerseyClientName") String jerseyClientName,
+        @JsonProperty("trustStore") TrustStoreConfiguration trustStore
+    ) {
+        super(uri, minRefreshDelay, maxRefreshDelay, expectedEntityId, client, jerseyClientName);
+        this.trustStore = trustStore;
+    }
+
     @NotNull
     @Valid
-    @JsonProperty
     private TrustStoreConfiguration trustStore;
 
     @Override

--- a/saml-metadata-bindings/src/main/java/uk/gov/ida/saml/metadata/TrustStorePathMetadataConfiguration.java
+++ b/saml-metadata-bindings/src/main/java/uk/gov/ida/saml/metadata/TrustStorePathMetadataConfiguration.java
@@ -1,5 +1,7 @@
 package uk.gov.ida.saml.metadata;
 
+import com.fasterxml.jackson.annotation.JsonAlias;
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.dropwizard.client.JerseyClientConfiguration;
 import uk.gov.ida.saml.metadata.factories.MetadataTrustStoreProvider;
@@ -17,25 +19,31 @@ import java.security.KeyStore;
  */
 @Deprecated
 public class TrustStorePathMetadataConfiguration extends MetadataConfiguration {
-    protected TrustStorePathMetadataConfiguration() {
-    }
 
-    public TrustStorePathMetadataConfiguration(String trustStorePath, String trustStorePassword, URI uri, Long minRefreshDelay, Long maxRefreshDelay, String expectedEntityId, JerseyClientConfiguration client, String jerseyClientName) {
+    @JsonCreator
+    public TrustStorePathMetadataConfiguration(
+            @JsonProperty("uri") @JsonAlias({ "url" }) URI uri,
+            @JsonProperty("minRefreshDelay") Long minRefreshDelay,
+            @JsonProperty("maxRefreshDelay") Long maxRefreshDelay,
+            @JsonProperty("expectedEntityId") String expectedEntityId,
+            @JsonProperty("client") JerseyClientConfiguration client,
+            @JsonProperty("jerseyClientName") @JsonAlias({ "client" }) String jerseyClientName,
+            @JsonProperty("trustStorePath") String trustStorePath,
+            @JsonProperty("trustStorePassword") String trustStorePassword
+    ) {
+        super(uri, minRefreshDelay, maxRefreshDelay, expectedEntityId, client, jerseyClientName);
         this.trustStorePath = trustStorePath;
         this.trustStorePassword = trustStorePassword;
     }
-
     /*
      * TrustStore configuration is used to do certificate chain validation when loading metadata
      */
     @NotNull
     @Valid
-    @JsonProperty
     private String trustStorePath;
 
     @NotNull
     @Valid
-    @JsonProperty
     private String trustStorePassword;
 
     @Override


### PR DESCRIPTION
Moved json properties into a JsonCreator constructor along with defaults
so that consumers can subclass and call super if they need to set different
defaults.

Authors: @andy-paine