### PR TITLE
BAU: Change subclasses of TrustStoreConfiguration to use common name

### DIFF
--- a/saml-metadata-bindings/src/main/java/uk/gov/ida/saml/metadata/EncodedTrustStoreConfiguration.java
+++ b/saml-metadata-bindings/src/main/java/uk/gov/ida/saml/metadata/EncodedTrustStoreConfiguration.java
@@ -13,10 +13,10 @@ public class EncodedTrustStoreConfiguration extends TrustStoreConfiguration {
     @Valid
     @NotNull
     @JsonProperty
-    private String trustStore;
+    private String store;
 
     @Override
     public KeyStore getTrustStore() {
-        return new KeyStoreLoader().load(new ByteArrayInputStream(Base64.getDecoder().decode(trustStore)), trustStorePassword);
+        return new KeyStoreLoader().load(new ByteArrayInputStream(Base64.getDecoder().decode(store)), trustStorePassword);
     }
 }

--- a/saml-metadata-bindings/src/main/java/uk/gov/ida/saml/metadata/FileBackedTrustStoreConfiguration.java
+++ b/saml-metadata-bindings/src/main/java/uk/gov/ida/saml/metadata/FileBackedTrustStoreConfiguration.java
@@ -12,12 +12,12 @@ public class FileBackedTrustStoreConfiguration extends TrustStoreConfiguration {
     @NotNull
     @Valid
     @JsonProperty
-    @JsonAlias({ "path" })
-    private String trustStorePath;
+    @JsonAlias({ "path", "trustStorePath" })
+    private String store;
 
 
     @Override
     public KeyStore getTrustStore() {
-        return new KeyStoreLoader().load(trustStorePath, trustStorePassword);
+        return new KeyStoreLoader().load(store, trustStorePassword);
     }
 }

--- a/saml-metadata-bindings/src/test/java/uk/gov/ida/saml/metadata/TrustStoreConfigurationTest.java
+++ b/saml-metadata-bindings/src/test/java/uk/gov/ida/saml/metadata/TrustStoreConfigurationTest.java
@@ -38,7 +38,7 @@ public class TrustStoreConfigurationTest {
     public void should_loadTrustStoreFromEncodedString() throws Exception {
         byte[] trustStore = Files.readAllBytes(new File(keyStoreRule.getAbsolutePath()).toPath());
         String encodedTrustStore = Base64.getEncoder().encodeToString(trustStore);
-        String jsonConfig = "{\"type\": \"encoded\", \"trustStore\": \"" + encodedTrustStore + "\", \"trustStorePassword\": \"" + keyStoreRule.getPassword() + "\"}";
+        String jsonConfig = "{\"type\": \"encoded\", \"store\": \"" + encodedTrustStore + "\", \"trustStorePassword\": \"" + keyStoreRule.getPassword() + "\"}";
         TrustStoreConfiguration config = objectMapper.readValue(jsonConfig, TrustStoreConfiguration.class);
 
         assertThat(config.getTrustStore()).isNotNull();


### PR DESCRIPTION
Changed both subclasses to use "store" as the common name and aliased
previous name for the file backed config (for backwards compat reasons)
As no apps are currently using the encoded trust stores, this can be freely
changed. The purpose of this change was so that anyone overriding config
only needs to change the "type" field in YAML to change the format without
also having to change to a new key.

Authors: @andy-paine