### PR TITLE
EID-419: Don't concatenate metadata URLs

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ subprojects {
       opensaml_version = '3.3.0'
       dropwizard_version = '1.2.0'
       ida_utils_version = '317'
-      trust_anchor_version = '1.0-7'
+      trust_anchor_version = '1.0-17'
     }
 
     group = "uk.gov.ida"

--- a/saml-metadata-bindings/src/main/java/uk/gov/ida/saml/metadata/EidasMetadataConfiguration.java
+++ b/saml-metadata-bindings/src/main/java/uk/gov/ida/saml/metadata/EidasMetadataConfiguration.java
@@ -18,8 +18,8 @@ public class EidasMetadataConfiguration {
                                       @JsonProperty("trustAnchorMinRefreshDelay") Long trustAnchorMinRefreshDelay,
                                       @JsonProperty("client") JerseyClientConfiguration client,
                                       @JsonProperty("jerseyClientName") String jerseyClientName,
-                                      @JsonProperty("trustStore") TrustStoreConfiguration trustStore,
-                                      @JsonProperty("metadataBaseUri") URI metadataBaseUri)
+                                      @JsonProperty("trustStore") TrustStoreConfiguration trustStore
+    )
     {
         this.trustAnchorUri = trustAnchorUri;
         this.minRefreshDelay = Optional.ofNullable(minRefreshDelay).orElse(60000L);
@@ -29,7 +29,6 @@ public class EidasMetadataConfiguration {
         this.client = Optional.ofNullable(client).orElse(new JerseyClientConfiguration());
         this.jerseyClientName = Optional.ofNullable(jerseyClientName).orElse("MetadataClient");
         this.trustStore = trustStore;
-        this.metadataBaseUri = metadataBaseUri;
     }
 
     private URI trustAnchorUri;
@@ -47,8 +46,6 @@ public class EidasMetadataConfiguration {
     private JerseyClientConfiguration client;
 
     private String jerseyClientName;
-
-    private URI metadataBaseUri;
 
     private TrustStoreConfiguration trustStore;
 
@@ -78,10 +75,6 @@ public class EidasMetadataConfiguration {
 
     public String getJerseyClientName() {
         return jerseyClientName;
-    }
-
-    public URI getMetadataBaseUri() {
-        return metadataBaseUri;
     }
 
     public KeyStore getTrustStore() {

--- a/saml-metadata-bindings/src/main/java/uk/gov/ida/saml/metadata/EidasMetadataResolverRepository.java
+++ b/saml-metadata-bindings/src/main/java/uk/gov/ida/saml/metadata/EidasMetadataResolverRepository.java
@@ -3,6 +3,7 @@ package uk.gov.ida.saml.metadata;
 import com.nimbusds.jose.jwk.JWK;
 import com.nimbusds.jose.util.X509CertUtils;
 import io.dropwizard.setup.Environment;
+import org.apache.commons.lang.StringEscapeUtils;
 import org.apache.xml.security.utils.Base64;
 import org.joda.time.DateTime;
 import org.opensaml.saml.metadata.resolver.MetadataResolver;
@@ -106,16 +107,13 @@ public class EidasMetadataResolverRepository {
         }
     }
 
-    private void addMetadataResolver(JWK trustAnchor) throws IOException, CertificateException, NoSuchAlgorithmException, KeyStoreException {
+    private void addMetadataResolver(JWK trustAnchor) throws CertificateException {
         MetadataResolver metadataResolver = dropwizardMetadataResolverFactory.createMetadataResolver(environment, createMetadataResolverConfiguration(trustAnchor));
         metadataResolvers.put(trustAnchor.getKeyID(), metadataResolver);
     }
 
-    private MetadataResolverConfiguration createMetadataResolverConfiguration(JWK trustAnchor)
-            throws UnsupportedEncodingException, CertificateException, KeyStoreException {
-
-        URI metadataUri = UriBuilder.fromUri(eidasMetadataConfiguration.getMetadataBaseUri())
-                .path(URLEncoder.encode(trustAnchor.getKeyID(), "UTF-8"))
+    private MetadataResolverConfiguration createMetadataResolverConfiguration(JWK trustAnchor) throws CertificateException {
+        URI metadataUri = UriBuilder.fromUri(trustAnchor.getKeyID())
                 .build();
 
         CertificateFactory certificateFactory = CertificateFactory.getInstance("X.509");

--- a/saml-metadata-bindings/src/test/java/uk/gov/ida/saml/metadata/EidasTrustAnchorResolverTest.java
+++ b/saml-metadata-bindings/src/test/java/uk/gov/ida/saml/metadata/EidasTrustAnchorResolverTest.java
@@ -107,7 +107,7 @@ public class EidasTrustAnchorResolverTest {
 
     private String createJwsWithACountryTrustAnchor(PrivateKey privateKey) throws ParseException, JOSEException, CertificateEncodingException {
         Generator generator = new Generator(privateKey, publicSigningCert);
-        return generator.generate(Arrays.asList(createJsonAnchor("https://eu.entity.id")));
+        return generator.generate(Arrays.asList(createJsonAnchor("https://eu.entity.id"))).serialize();
     }
 
     private String createJsonAnchor(String kid) {


### PR DESCRIPTION
We should treat the key ID as the full URL to the location of that
country's metadata as it makes things simpler to understand.

Author: @vixus0